### PR TITLE
Airflow security

### DIFF
--- a/scheduler.ml/airflow-svc.yaml
+++ b/scheduler.ml/airflow-svc.yaml
@@ -8,7 +8,7 @@ metadata:
 #  annotations:
 #    domainName: airflow.your.domain.com
 spec:
-  type: LoadBalancer
+  type: NodePort
   ports:
   - name: airflow-webui
     port: 80

--- a/scheduler.ml/airflow/config/airflow/airflow.cfg
+++ b/scheduler.ml/airflow/config/airflow/airflow.cfg
@@ -83,6 +83,8 @@ default_owner = Airflow
 
 
 [webserver]
+authenticate = True
+auth_backend = airflow.contrib.auth.backends.password_auth
 # The base url of your website as airflow cannot guess what domain or
 # cname you are using. This is used in automated emails that
 # airflow sends to point links to the right web server


### PR DESCRIPTION
# Part A: the ssh tunnel.

With `NodePort` change to the svc.yaml, to connect to airflow interface (or the celery one), you'll need to use the ssh-tunnel.

This line will allow you to see the airflow interface on `localhost:8082`.
```
kubectl port-forward \
    $(kubectl get pod \
    --selector=app=scheduler-airflow -o \
    jsonpath={.items..metadata.name}) 8082:8080
```
# Part B: user\password auth

To use this update, you need to update the airflow docker image to have the new config file with the change.

To add a new user you can use this instructions: https://airflow.incubator.apache.org/security.html
Or to run this line if you also added that script (`airflow-security.py`) which I had in a pull request to source.ml:
```
kubectl exec -it $(kubectl get pods \
    --selector=app=scheduler-airflow -o \
    jsonpath={.items..metadata.name}) \
            python /root/volumes/source.ml/scheduler.ml/airflow/airflow-security.py \
            <your-name> <your-password> <your-email>

```